### PR TITLE
Adds spanish locale {Argentina} (es-AR )

### DIFF
--- a/locales/es-AR.yml
+++ b/locales/es-AR.yml
@@ -1,4 +1,4 @@
-en:
+es-AR:
   devise:
     confirmations:
       new:


### PR DESCRIPTION
This commits adds a spanish locale, specific to Argentina but could actually be used as a locale file for any other spanish speaking application.
