### PR TITLE
Missing translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ pkg
 # For rubinius:
 #*.rbc
 .localeapp
+
+# For RubyMine
+.idea

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -18,8 +18,8 @@
   <div><%= f.submit t('.update', :default => "Update") %></div>
 <% end %>
 
-<h3>Cancel my account</h3>
+<h3><%= t('.cancel_my_account', :default => 'Cancel my account') %></h3>
 
-<p>Unhappy? <%= link_to t('.cancel_my_account', :default => "Cancel my account"), registration_path(resource_name), :data => { :confirm => t('.are_you_sure', :default => "Are you sure?") }, :method => :delete %>.</p>
+<p><%= t('.unhappy', :default => 'Unhappy') %>? <%= link_to t('.cancel_my_account', :default => "Cancel my account"), registration_path(resource_name), :data => { :confirm => t('.are_you_sure', :default => "Are you sure?") }, :method => :delete %>.</p>
 
 <%= link_to "Back", :back %>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -39,6 +39,8 @@ en:
         title: Edit %{resource}
         we_need_your_current_password_to_confirm_your_changes: we need your current password to confirm your changes
         update: Update
+        cancel_my_account: Cancel my account
+        unhappy: Unhappy
       new:
         sign_up: Sign up
     sessions:


### PR DESCRIPTION
I added two strings that were not translatable ("Cancel my account" and "Unhappy") in registrations/edit
