### PR TITLE
Add railtie to load locales automatically

### DIFF
--- a/lib/devise-i18n-views.rb
+++ b/lib/devise-i18n-views.rb
@@ -5,7 +5,7 @@ module DeviseI18nViews
   
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'rails-i18n-views' do |app|
-      RailsI18n::Railtie.instance_eval do
+      DeviseI18nViews::Railtie.instance_eval do
         pattern = pattern_from app.config.i18n.available_locales
 
         files = Dir[File.join(File.dirname(__FILE__), '../locales', "#{pattern}.yml")]


### PR DESCRIPTION
Like in devise-i18n gem
https://github.com/tigrish/devise-i18n/blob/master/lib/devise-i18n.rb

This way, the step of running `rails g devise:views:locale it` is just optional.
All locales are automatically available
