### PR TITLE
Fix translation of resource name in registrations/edit

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t('.title', :resource => resource_name.to_s.humanize , :default => 'Edit #{resource_name.to_s.humanize}') %></h2>
+<h2><%= t('.title', :resource => resource_class.model_name.human , :default => 'Edit #{resource_name.to_s.humanize}') %></h2>
 
 <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |f| %>
   <%= devise_error_messages! %>


### PR DESCRIPTION
Until now ´resource_name.to_s.humanize´ was used to translate the resource name. This approach does not use the translations in the YAML file. ´resource_class.model_name.human´ does.
