### PR TITLE
Fixing undefined YAML error

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require 'rspec'
+require 'yaml' unless defined?(YAML)
 require 'i18n-spec'


### PR DESCRIPTION
Rspec thrown undefined constant YAML while running I18n-Spec on the project. This small patch fixes it.
