### PR TITLE
Fixing toplevel tag of spanish (es-ES) locale

### DIFF
--- a/locales/es-ES.yml
+++ b/locales/es-ES.yml
@@ -1,4 +1,4 @@
-es:
+es-ES:
   devise:
     confirmations:
       new:


### PR DESCRIPTION
Fixing toplevel tag of Spanish (es-ES) locale. It was simply 'es' but toplevel tag must match filename, so it should be 'es-ES'
