### PR TITLE
Adding 'rake spec'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,3 +24,7 @@ Jeweler::Tasks.new do |gem|
   # dependencies defined in Gemfile
 end
 Jeweler::RubygemsDotOrgTasks.new
+
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new


### PR DESCRIPTION
This is a quick patch to add 'rake spec'. Do not merge it if it is does not fit into your environment.
