### PR TITLE
Support inheriting a locale from the record

### DIFF
--- a/lib/devise-i18n-views.rb
+++ b/lib/devise-i18n-views.rb
@@ -1,4 +1,6 @@
 require 'rails'
+require 'devise'
+
 module DeviseI18nViews
   class Engine < ::Rails::Engine
   end
@@ -20,4 +22,19 @@ module DeviseI18nViews
       array.blank? ? '*' : "{#{array.join ','}}"
     end                
   end
+end
+
+# support inheriting a locale from the record when sending an email
+module Devise::Mailers::Helpers
+  def devise_mail_with_locale(record, *args)
+    original = -> { devise_mail_without_locale record, *args }
+
+    if record.respond_to? :locale
+      I18n.with_locale record.locale, &original
+    else
+      original.call
+    end
+  end
+
+  alias_method_chain :devise_mail, :locale
 end


### PR DESCRIPTION
This pull-request adds support to send a devise email in the locale which is set for the record.

It's helpful for example when you're using `devise-async` since in background process information about original locale is lost.
