### PR TITLE
Unshifting locales in railtie

### DIFF
--- a/lib/devise-i18n-views.rb
+++ b/lib/devise-i18n-views.rb
@@ -9,7 +9,7 @@ module DeviseI18nViews
         pattern = pattern_from app.config.i18n.available_locales
 
         files = Dir[File.join(File.dirname(__FILE__), '../locales', "#{pattern}.yml")]
-        I18n.load_path.concat(files)
+        I18n.load_path.unshift(*files)
       end      
     end
     


### PR DESCRIPTION
Few months ago devise-i18n-views had no overlapping locales with devise-i18n gem. 
Now i can see that there are many empty values in most of locales that nullify devise-i18n translations resulting into many "translate missing" errors. Is there any idea on that? What do you think about such incompatibility?
Maybe while you are using empty values in locales it would be better idea to use `I18n.load_path.unshift(*files)` instead of  `I18n.load_path.concat(files)` in railtie?
