### PR TITLE
Add missing translations for es-ES and ca

### DIFF
--- a/locales/ca.yml
+++ b/locales/ca.yml
@@ -2,11 +2,11 @@ ca:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
+        current_password: Contrasenya actual
+        email: Email
+        password: Contrasenya
+        password_confirmation: Confirmar contrasenya
+        remember_me: Recordar-me
     models:
       user: Usuari
   devise:
@@ -42,7 +42,7 @@ ca:
       edit:
         are_you_sure: Estàs segur?
         cancel_my_account: Cancel·lar el meu compte
-        currently_waiting_confirmation_for_email: 
+        currently_waiting_confirmation_for_email: "Esperant confirmació de: %{email}"
         leave_blank_if_you_don_t_want_to_change_it: deixa'l en blanc si no el vols canviar
         title: Editar %{resource}
         unhappy: Descontent
@@ -55,7 +55,7 @@ ca:
         sign_in: Iniciar sessió
     shared:
       links:
-        back: 
+        back: Tornar
         didn_t_receive_confirmation_instructions: No has rebut les instruccions de confirmació?
         didn_t_receive_unlock_instructions: No has rebut les instruccions de desbloqueig?
         forgot_your_password: Has oblidat la teva contrasenya?

--- a/locales/es-ES.yml
+++ b/locales/es-ES.yml
@@ -2,13 +2,13 @@ es-ES:
   activerecord:
     attributes:
       user:
-        current_password: 
-        email: 
-        password: 
-        password_confirmation: 
-        remember_me: 
+        current_password: Contraseña actual
+        email: Email
+        password: Contraseña
+        password_confirmation: Confirmar contraseña
+        remember_me: Recordarme
     models:
-      user: 
+      user: Usuario
   devise:
     confirmations:
       new:
@@ -42,7 +42,7 @@ es-ES:
       edit:
         are_you_sure: "¿Estás segur@?"
         cancel_my_account: Cancelar mi cuenta
-        currently_waiting_confirmation_for_email: 
+        currently_waiting_confirmation_for_email: "Esperando confirmación de: %{email}"
         leave_blank_if_you_don_t_want_to_change_it: déjalo en blanco si no lo quieres cambiar
         title: Editar %{resource}
         unhappy: Descontento
@@ -55,7 +55,7 @@ es-ES:
         sign_in: Iniciar sesión
     shared:
       links:
-        back: 
+        back: Volver
         didn_t_receive_confirmation_instructions: "¿No has recibido las instrucciones de confirmación?"
         didn_t_receive_unlock_instructions: "¿No has recibido las instrucciones de desbloqueo?"
         forgot_your_password: "¿Olvidaste tu contraseña?"


### PR DESCRIPTION
Hi, I’ve translated the missing es-ES and ca keys
