### PR TITLE
Feature/ar he fix

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -65,3 +65,8 @@ en:
         password_confirmation: "Password confirmation"
         current_password: "Current password"
         remember_me: "Remember me"
+        sign_in_count: "Sign in count"
+        current_sign_in_at: "Signed in at"
+        last_sign_in_at: "Last sign in at"
+        current_sign_in_ip: "Signed in from IP"
+        last_sign_in_ip: "Last sign in from IP"

--- a/locales/he.yml
+++ b/locales/he.yml
@@ -1,4 +1,4 @@
-en:
+he:
   devise:
     confirmations:
       new:


### PR DESCRIPTION
Hebrew translation yml had :en as the locale key.