### PR TITLE
Fix bug with devise version 4 and reset password instructions

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -3,7 +3,7 @@
 
 <p><%= t('.instruction', :default => "Someone has requested a link to change your password, and you can do this through the link below.") %></p>
 
-<p><%= link_to t('.action', :default => "Change my password"), edit_password_url(@resource, :reset_password_token => (Devise::VERSION.start_with?('3.') ? @token : @resource.reset_password_token)) %></p>
+<p><%= link_to t('.action', :default => "Change my password"), edit_password_url(@resource, :reset_password_token => (Devise::VERSION.start_with?('3.') ? @resource.reset_password_token : @token)) %></p>
 
 <p><%= t('.instruction_2', :default => "If you didn't request this, please ignore this email.") %></p>
 <p><%= t('.instruction_3', :default => "Your password won't change until you access the link above and create a new one.") %></p>


### PR DESCRIPTION
I've spent a lot of time trying to fix `Reset password token is invalid`  devise error in my user reset password tests. Finally I've found the reason.

If you want to find it you should compare these two version of that mail body:
- Official one: https://github.com/plataformatec/devise/blob/master/app/views/devise/mailer/reset_password_instructions.html.erb#L5
- And yours: https://github.com/mcasimir/devise-i18n-views/blob/master/app/views/devise/mailer/reset_password_instructions.html.erb#L6

There was some typo, I've fixed it.
